### PR TITLE
Move the wait before the draining of the queue

### DIFF
--- a/b64filter.go
+++ b/b64filter.go
@@ -254,6 +254,10 @@ func main() {
 	}
 	cmdin.Close()
 
+	if err = cmd.Wait(); err != nil {
+		log.Fatalf("error waiting for command: %v", err)
+	}
+
 	// wait for the queue to drain
 	for {
 		if counts.Empty() {
@@ -266,9 +270,6 @@ func main() {
 	// it is required that all reading from the command is done before
 	// calling Wait(). 
 	_ = <-done
-	if err = cmd.Wait(); err != nil {
-		log.Fatalf("error waiting for command: %v", err)
-	}
 
 	log.Printf("processed %v documents", i)
 }


### PR DESCRIPTION
Better fix for #3. Tested by translating a bunch of languages in Hieu's data set without issues.

Current bug is that the program will block on the for-loop that waits for all the queues to drain. This however depends on the write coroutine, but that one is stuck on readNLines since the captured command won't produce more lines if it failed.

This patch moves the explicit wait for return code of the captured command before trying to drain and close the queues. If the captured command failed, Wait() will return with an error. If it hasn't we can continue as normal.

This does not fix any issues where the captured command doesn't fail, but doesn't return the same number of lines as it was given either. In that case it could well be true that readNLines will never return and the drain queues for-loop will never stop.